### PR TITLE
Correct isinf() scope.

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -74,7 +74,7 @@ bool contains_any_zero(Rcpp::NumericVector x)
 bool contains_any_inf(Rcpp::NumericVector x)
 {
     for (auto el : x)
-        if (isinf(el))
+        if (std::isinf(el))
             return true;
     return false;
 }
@@ -91,7 +91,7 @@ bool contains_any_neg(Rcpp::NumericVector x)
 bool contains_any_nas_or_inf(Rcpp::NumericVector x)
 {
     for (auto el : x)
-        if (ISNAN(el) || isinf(el))
+        if (ISNAN(el) || std::isinf(el))
             return true;
     return false;
 }


### PR DESCRIPTION
Add std scope to isinf(), as already done in other places across the repo. This fixed the Windows build in conda-forge (https://github.com/conda-forge/staged-recipes/pull/17116).